### PR TITLE
Feature/set fog of war for raas

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,11 @@ Grafana:
            <p>Fog of war mode to set.</p>
            <h6>Default</h6>
            <pre><code>1</code></pre></li>
+<li><h4>allowedForGameModes</h4>
+           <h6>Description</h6>
+           <p>Allowed game modes for enabling fog of war</p>
+           <h6>Default</h6>
+           <pre><code>[]</code></pre></li>
 <li><h4>delay</h4>
            <h6>Description</h6>
            <p>Delay before setting fog of war mode.</p>

--- a/README.md
+++ b/README.md
@@ -787,7 +787,13 @@ Grafana:
            <h6>Description</h6>
            <p>Allowed game modes for enabling fog of war</p>
            <h6>Default</h6>
-           <pre><code>[]</code></pre></li>
+           <pre><code>[
+  "AAS",
+  "RAAS",
+  "Invasion",
+  "Insurgency",
+  "Skirmish"
+]</code></pre></li>
 <li><h4>delay</h4>
            <h6>Description</h6>
            <p>Delay before setting fog of war mode.</p>

--- a/config.json
+++ b/config.json
@@ -209,7 +209,13 @@
       "plugin": "FogOfWar",
       "enabled": false,
       "mode": 1,
-      "allowedForGameModes": [],
+      "allowedForGameModes": [
+        "AAS",
+        "RAAS",
+        "Invasion",
+        "Insurgency",
+        "Skirmish"
+      ],
       "delay": 10000
     },
     {

--- a/config.json
+++ b/config.json
@@ -209,6 +209,7 @@
       "plugin": "FogOfWar",
       "enabled": false,
       "mode": 1,
+      "allowedForGameModes": [],
       "delay": 10000
     },
     {

--- a/squad-server/plugins/fog-of-war.js
+++ b/squad-server/plugins/fog-of-war.js
@@ -16,6 +16,11 @@ export default class FogOfWar extends BasePlugin {
         description: 'Fog of war mode to set.',
         default: 1
       },
+      allowedForGameModes: {
+        required: false,
+        description: 'Allowed game modes for enabling fog of war',
+        default: []
+      },
       delay: {
         required: false,
         description: 'Delay before setting fog of war mode.',
@@ -40,8 +45,15 @@ export default class FogOfWar extends BasePlugin {
 
   async onNewGame() {
     setTimeout(async () => {
-      const currentMap = await this.server.rcon.getCurrentMap();
-      this.options.mode = currentMap.layer.includes('RAAS') ? 1 : 0;
+      if (this.options.mode === 1 && this.options.allowedForGameModes.length > 0) {
+        const currentMap = await this.server.rcon.getCurrentMap();
+        this.options.mode = this.options.allowedForGameModes.some((gameMode) =>
+          currentMap.layer.includes(gameMode)
+        )
+          ? 1
+          : 0;
+      }
+
       await this.server.rcon.setFogOfWar(this.options.mode);
     }, this.options.delay);
   }

--- a/squad-server/plugins/fog-of-war.js
+++ b/squad-server/plugins/fog-of-war.js
@@ -19,7 +19,7 @@ export default class FogOfWar extends BasePlugin {
       allowedForGameModes: {
         required: false,
         description: 'Allowed game modes for enabling fog of war',
-        default: []
+        default: ['AAS', 'RAAS', 'Invasion', 'Insurgency', 'Skirmish']
       },
       delay: {
         required: false,
@@ -45,16 +45,17 @@ export default class FogOfWar extends BasePlugin {
 
   async onNewGame() {
     setTimeout(async () => {
-      if (this.options.mode === 1 && this.options.allowedForGameModes.length > 0) {
+      let isFogEnabled = this.options.mode;
+      if (isFogEnabled === 1 && this.options.allowedForGameModes.length > 0) {
         const currentMap = await this.server.rcon.getCurrentMap();
-        this.options.mode = this.options.allowedForGameModes.some((gameMode) =>
+        isFogEnabled = this.options.allowedForGameModes.some((gameMode) =>
           currentMap.layer.includes(gameMode)
         )
           ? 1
           : 0;
       }
 
-      await this.server.rcon.setFogOfWar(this.options.mode);
+      await this.server.rcon.setFogOfWar(isFogEnabled);
     }, this.options.delay);
   }
 }

--- a/squad-server/plugins/fog-of-war.js
+++ b/squad-server/plugins/fog-of-war.js
@@ -39,8 +39,10 @@ export default class FogOfWar extends BasePlugin {
   }
 
   async onNewGame() {
-    setTimeout(() => {
-      this.server.rcon.setFogOfWar(this.options.mode);
+    setTimeout(async () => {
+      const currentMap = await this.server.rcon.getCurrentMap();
+      this.options.mode = currentMap.layer.includes('RAAS') ? 1 : 0;
+      await this.server.rcon.setFogOfWar(this.options.mode);
     }, this.options.delay);
   }
 }


### PR DESCRIPTION
Added posibility to configure FogOfWar for selected game modes
Just add desirable mode to config at section at section`"plugin": "FogOfWar",` to `allowedForGameModes` field

For example:
`"allowedForGameModes": ["RAAS"]`

~~disclaimer: changes have not yet been tested at locall environment~~

checked locally - OK